### PR TITLE
Remove tile.setBackgroundColor

### DIFF
--- a/src/Tile.js
+++ b/src/Tile.js
@@ -103,15 +103,6 @@ class Tile {
   }
 
   /**
-   * @method setBackgroundColor
-   * @param {string} color
-   * @returns {void}
-   */
-  setBackgroundColor(color) {
-    game.render.options.background = color;
-  }
-
-  /**
    * @method createRectangle
    * @param {Number} x - the center x value
    * @param {Number} y - the center y value


### PR DESCRIPTION
This method is broken. It's also hard to use, since the user won't know
how to reset it.