### PR TITLE
Don't use console.log in docs/Tile.md

### DIFF
--- a/docs/Tile.md
+++ b/docs/Tile.md
@@ -186,7 +186,7 @@ tile.onTick = function () {
 #### Example: Printing the width and height of the tile
 
 ```ts
-console.log(`${tile.width} x ${tile.height}`);
+alert(`${tile.width} x ${tile.height}`);
 // Output:
 // 500 x 500
 ```


### PR DESCRIPTION
```diff
-console.log(`${tile.width} x ${tile.height}`);
+alert(`${tile.width} x ${tile.height}`);
```

because `alert` is very visible.